### PR TITLE
feat: implement getFinalImage

### DIFF
--- a/src/pages/api/getFinalImage.js
+++ b/src/pages/api/getFinalImage.js
@@ -1,4 +1,41 @@
-// 임시 API
-export default function getFinalImage(req, res) {
-  res.status(200).json({ image: '/images/admiration.png' });
+import {getMongoClient} from "../../../lib/MongodbClient";
+
+const TAGS = [
+  ["유직", "무직"],
+  ["활동", "휴식"],
+  ["바쁨", "여유"],
+  ["심심", "유흥", "지침", "귀가"],
+  ["흥미", "화남", "행복", "사랑", "신남" ,"허탈", "냉소", "지루", "속상"],
+  ["거지", "부자"]
+]
+
+export default async function getFinalImage(req, res) {
+  let { query } = req;
+
+  try {
+    let client = await getMongoClient();
+    let db = client.db(process.env.MONGODB_DB);
+    let collection = db.collection(process.env.MONGODB_COLLECTION);
+    let data = await collection.find({ tag: {$in: getTags(query)} }).toArray();
+
+    let fileNames = data.map((item) => {
+      return item.filename
+    });
+
+    res.status(200).json({ imageNames: fileNames });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+
+}
+
+function getTags(query) {
+  let idx = query.tags.split("").map((item) => {
+    return parseInt(item);
+  });
+
+  return TAGS.map((item, index) => {
+    return item[idx[index]];
+  });
 }

--- a/src/pages/api/getFinalImage.js
+++ b/src/pages/api/getFinalImage.js
@@ -12,6 +12,11 @@ const TAGS = [
 export default async function getFinalImage(req, res) {
   let { query } = req;
 
+  if (!validateQuery(query)) {
+    res.status(400).json({ error: "Bad Request" });
+    return;
+  }
+
   try {
     let client = await getMongoClient();
     let db = client.db(process.env.MONGODB_DB);
@@ -38,4 +43,29 @@ function getTags(query) {
   return TAGS.map((item, index) => {
     return item[idx[index]];
   });
+}
+
+function validateQuery(query) {
+  if (query.tags === undefined) {
+    return false;
+  }
+
+  if (query.tags.length !== 6) {
+    return false;
+  }
+
+  let tags = query.tags.split("");
+  let isValid = true;
+
+  tags.forEach((item, idx) => {
+    let tag = parseInt(item);
+    if (isNaN(tag)) {
+      isValid = false;
+    }
+    if (tag >= TAGS[idx].length) {
+      isValid = false;
+    }
+  });
+
+  return isValid;
 }


### PR DESCRIPTION
this api takes tags query string as input and return matching image file names in json type data.

<!-- PR 제목입니다 -->
<!-- [Feat] 어쩌구 저쩌구 -->
<!-- [Fix] 어쩌구 저쩌구 -->

## 📌 PR 타입

<!-- 해당하는 부분에 x 표시 해 주세요. -->

- [x] Feature
- [ ] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용
getFinalImage api 구현

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)
HTTP method: GET
URL: ${DOMAIN}/api/getFinalImage?tags=000000

Input은 tags 쿼리스트링으로 6자리 숫자로 구성된 문자열을 입력해야합니다.

Response Example:
```json
{
  "imageNames": ["1", "2", "3", "4", "5", "6", "7"]
}
```