### PR TITLE
feat: 초기 마운트때 imageUrl 설정해서 다운로드 정상적으로 되도록 수정

### DIFF
--- a/src/componets/Finish/index.jsx
+++ b/src/componets/Finish/index.jsx
@@ -13,6 +13,8 @@ const Finish = ({ answers, setAnswers, setStep, fetchedResult, fetchZzal }) => {
 
   useEffect(() => {
     fetchZzal();
+
+    setImageUrl(`/images/zzal/${fetchedResult.imageNames[0]}.png`);
   }, []);
 
   const shareClickHandler = () => {


### PR DESCRIPTION
<!-- PR 제목입니다 -->
<!-- [Feat] 어쩌구 저쩌구 -->
<!-- [Fix] 어쩌구 저쩌구 -->

## 📌 PR 타입

<!-- 해당하는 부분에 x 표시 해 주세요. -->

- [ ] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용

<!-- 작업 내용을 작성합니다 -->
다운로드 버튼을 클릭 하면 imageUrl을 유저 컴퓨터에 다운로드 합니다.
기존 코드에는 짤을 fetch 해서 setImageUrl 하는 로직이 없어 imageUrl이 비어있어 그 부분 추가했습니다.

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)

<!-- 없다면 적지 않으셔도 됩니다. -->
