### PR TITLE
fix: 초기 마운트때 imageUrl 설정해서 다운로드 정상적으로 되도록 수정

### DIFF
--- a/src/componets/Finish/index.jsx
+++ b/src/componets/Finish/index.jsx
@@ -8,7 +8,7 @@ import { ToastContainer } from 'react-toastify';
 import useToast from '@/hooks/useToast';
 
 const Finish = ({ answers, setAnswers, setStep, fetchedResult, fetchZzal }) => {
-  const [imageUrl, setImageUrl] = useState();
+  const [imageUrl, setImageUrl] = useState('');
   const router = useRouter();
 
   useEffect(() => {
@@ -53,7 +53,7 @@ const Finish = ({ answers, setAnswers, setStep, fetchedResult, fetchZzal }) => {
           />
           <S.Container>
             <Image
-              src={imageUrl || `/images/zzal/${fetchedResult?.imageNames[0]}.png`}
+              src={imageUrl}
               priority
               fill
               placeholder="blur"

--- a/src/componets/Finish/index.jsx
+++ b/src/componets/Finish/index.jsx
@@ -15,6 +15,10 @@ const Finish = ({ answers, setAnswers, setStep, fetchedResult, fetchZzal }) => {
     fetchZzal();
   }, []);
 
+  useEffect(() => {
+    setImageUrl(`/images/zzal/${fetchedResult?.imageNames[0]}.png`);
+  }, [fetchedResult]);
+
   const shareClickHandler = () => {
     if (typeof window === 'undefined') return;
     const currentUrl = Meta.url + router.asPath;


### PR DESCRIPTION
<!-- PR 제목입니다 -->
<!-- [Feat] 어쩌구 저쩌구 -->
<!-- [Fix] 어쩌구 저쩌구 -->

## 📌 PR 타입

<!-- 해당하는 부분에 x 표시 해 주세요. -->

- [x] Feature
- [x] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [ ] Other

## ✨ 작업 내용

<!-- 작업 내용을 작성합니다 -->
다운로드 버튼을 클릭 하면 imageUrl을 유저 컴퓨터에 다운로드 합니다.
기존 코드에는 짤을 fetch 해서 setImageUrl 하는 로직이 없어 비어있는 imageUrl을 다운받지 못했습니다.
선정된 짤에 맞게 imageUrl 바꾸는 로직 추가했습니다.

추가적으로 imageUrl 없을때 불필요하게 삼항연산자를 사용하던 코드도 정리했습니다.



## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)

<!-- 없다면 적지 않으셔도 됩니다. -->
