### PR TITLE
chore: update pull request scripts

### DIFF
--- a/.github/workflows/backend-pull-request-test.yml
+++ b/.github/workflows/backend-pull-request-test.yml
@@ -1,13 +1,10 @@
-name: Check Backend
+name: Test Backend Pull Request
 
 on:
   pull_request:
     types: [opened, reopened]
     branches:
       - main
-    paths:
-      - "backend/**"
-      - ".github/workflows/backend-**.yml"
 
 permissions:
   contents: read
@@ -15,7 +12,25 @@ permissions:
   id-token: write
 
 jobs:
+  files-changed:
+    name: Determine if files changed
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - backend/**
+              - .github/workflows/backend-**.yml
+    outputs:
+      filesChanged: ${{ steps.changes.outputs.src }}
+
   test:
+    needs: [files-changed]
+    if: needs.files-changed.outputs.filesChanged == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/frontend-pull_request_test.yml
+++ b/.github/workflows/frontend-pull_request_test.yml
@@ -1,13 +1,10 @@
-name: Check NextJs build
+name: Test Frontend Pull Request
 
 on:
   pull_request:
     types: [opened, reopened]
     branches:
       - main
-    paths:
-      - "frontend/**"
-      - ".github/workflows/frontend-**.yml"
 
 permissions:
   contents: read
@@ -15,7 +12,25 @@ permissions:
   id-token: write
 
 jobs:
+  files-changed:
+    name: Determine if files changed
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - frontend/**
+              - .github/workflows/frontend-**.yml
+    outputs:
+      filesChanged: ${{ steps.changes.outputs.src }}
+
   test:
+    needs: [ files-changed ]
+    if: needs.files-changed.outputs.filesChanged == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## 📌 PR 타입

<!-- 해당하는 부분에 x 표시 해 주세요. -->

- [ ] Feature
- [ ] BugFix
- [ ] Refactor
- [ ] Code Style Update
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation
- [x] Other

## ✨ 작업 내용

Github actions 스크립트에서 제공하는 `on.pull_request.paths` 기능은 모노레포에서 다중 프로젝트에 대한 브랜치 보호 기능을 완벽하게 지원하지 않습니다.
 
특히, 백엔드와 프론트엔드 어디에도 속하지 않는 파일의 변화가 있는 경우 어떠한 test job도 수행되지 않아 merge를 admin 권한으로 강제 수행해야합니다.

따라서 스크립트 단계에서 파일의 변화를 파악하고 관련 테스트를 수행하거나 건너뛰도록 스크립트를 수행하였습니다.

process:
1. files-changed job에서 관련 프로젝트 폴더 내부 파일 변화를 확인하고 `boolean` 값을 갖는 `filesChanged` output을 반환
2. test job에서 `filesChanged`의 값에 따라 본 테스트를 수행

아무런 변화가 없다면 test job의 메인 테스트는 스킵되며 테스트가 완료됩니다.

## 🙏 기타 참고 사항 (없다면 적지 않으셔도 됩니다.)

<!-- 없다면 적지 않으셔도 됩니다. -->
